### PR TITLE
add in event data checks

### DIFF
--- a/sitemap.py
+++ b/sitemap.py
@@ -4,7 +4,7 @@ import os.path
 import logging
 import re
 import requests
-from datetime import *
+from datetime import datetime, timedelta
 
 # local
 import config


### PR DESCRIPTION
## Description

This is used to limit only the most recent (within a year and a half) events. This happens on the folders if they are old enough, but also on pages.

## Size and Type of change

- Small Change - 1 person needs to review this
- New feature
- (Caleb) Contact Marketing

## How Has This Been Tested?

- I did a lot of local testing on events folders. At the end, I looked at the xml that was created for events. It seemed like it only had things within a year and a half.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)