### PR TITLE
Create hidden page txt file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ target/
 
 config.py
 /sitemap-files/
+
+venv

--- a/sitemap.py
+++ b/sitemap.py
@@ -89,7 +89,7 @@ def inspect_page(page_id):
         path = page['asset']['page']['path']
 
         if 'hide-from-sitemap' in list(md.keys()) and md['hide-from-sitemap'] == "Hide":
-            hidden_pages.append("https://www.bethel.edu/" + path + "\n")
+            hidden_pages.append("https://www.bethel.edu/" + path + ",")
             return
 
         if 'require-authentication' in list(md.keys()) and md['require-authentication'] == "Yes":
@@ -179,12 +179,14 @@ sitemap()
 
 
 def hidden_files():
+    hidden = ''
+    for item in hidden_pages:
+        hidden = hidden + str(item)
+    hidden = hidden.split(",")
     with open(config.HIDDEN_FILE, 'w') as file:
-        for item in hidden_pages:
-            file.write(item)
+        file.write("\n".join(hidden))
     with open(config.HIDDEN_PRODUCTION_FILE, 'w') as file:
-        for item in hidden_pages:
-            file.write(item)
+        file.write("\n".join(hidden))
 
 
 hidden_files()

--- a/sitemap.py
+++ b/sitemap.py
@@ -187,15 +187,15 @@ sitemap()
 # Writes them to the corresponding production and non-production .txt files from config
 def hidden_files():
     hidden = hidden_pages.split(",")
-    with open(config.HIDDEN_FILE, 'w') as file:
+    with open(config.HIDDEN_PAGES_FILE, 'w') as file:
         file.write("\n".join(hidden))
-    with open(config.HIDDEN_PRODUCTION_FILE, 'w') as file:
+    with open(config.HIDDEN_PAGES_PRODUCTION_FILE, 'w') as file:
         file.write("\n".join(hidden))
 
     hidden = hidden_folders.split(",")
-    with open(config.HIDDEN_FOLDER, 'w') as file:
+    with open(config.HIDDEN_FOLDERS_FILE, 'w') as file:
         file.write("\n".join(hidden))
-    with open(config.HIDDEN_PRODUCTION_FOLDER, 'w') as file:
+    with open(config.HIDDEN_FOLDERS_PRODUCTION_FILE, 'w') as file:
         file.write("\n".join(hidden))
 
 

--- a/sitemap.py
+++ b/sitemap.py
@@ -13,6 +13,8 @@ import sentry_sdk
 from sentry_sdk import configure_scope
 from bu_cascade.cascade_connector import Cascade
 
+hidden_pages = []
+
 if config.SENTRY_URL:
     from sentry_sdk.integrations.flask import FlaskIntegration
     sentry_sdk.init(dsn=config.SENTRY_URL, integrations=[FlaskIntegration()])
@@ -87,6 +89,7 @@ def inspect_page(page_id):
         path = page['asset']['page']['path']
 
         if 'hide-from-sitemap' in list(md.keys()) and md['hide-from-sitemap'] == "Hide":
+            hidden_pages.append("https://www.bethel.edu/" + path + "\n")
             return
 
         if 'require-authentication' in list(md.keys()) and md['require-authentication'] == "Yes":
@@ -173,3 +176,15 @@ def sitemap():
 
 
 sitemap()
+
+
+def hidden_files():
+    with open(config.HIDDEN_FILE, 'w') as file:
+        for item in hidden_pages:
+            file.write(item)
+    with open(config.HIDDEN_PRODUCTION_FILE, 'w') as file:
+        for item in hidden_pages:
+            file.write(item)
+
+
+hidden_files()

--- a/sitemap.py
+++ b/sitemap.py
@@ -14,6 +14,7 @@ from sentry_sdk import configure_scope
 from bu_cascade.cascade_connector import Cascade
 
 hidden_pages = ""
+hidden_folders = ""
 
 if config.SENTRY_URL:
     from sentry_sdk.integrations.flask import FlaskIntegration
@@ -26,18 +27,21 @@ cascade_api = Cascade(config.SOAP_URL, config.CASCADE_LOGIN, config.SITE_ID, con
 
 # Just putting this here to work on it. Move out of tinker once the Cascade stuff is more portable
 def inspect_folder(folder_id):
+    global hidden_folders
     folder = cascade_api.read(folder_id, asset_type="folder")
     if not folder:
         # typically a permision denied error from the Web Services read call.
         return
     try:
         md = folder['asset']['folder']['metadata']['dynamicFields']
+        path = folder['asset']['folder']['path']
     except KeyError:
         # folder has been deleted
         return
     md = get_md_dict(md)
 
     if 'hide-from-sitemap' in list(md.keys()) and md['hide-from-sitemap'] == "Hide":
+        hidden_folders = hidden_folders + ("https://www.bethel.edu/" + path + ",")
         return
 
     if 'require-authentication' in list(md.keys()) and md['require-authentication'] == "Yes":
@@ -178,13 +182,20 @@ def sitemap():
 
 sitemap()
 
-# Takes in a string containing the hidden files and splits them based on commas.
-# Writes them to HIDDEN_FILE and HIDDEN_PRODUCTION_FILE
+
+# Takes in a string containing the hidden files and folders and splits them based on commas.
+# Writes them to the corresponding production and non-production .txt files from config
 def hidden_files():
     hidden = hidden_pages.split(",")
     with open(config.HIDDEN_FILE, 'w') as file:
         file.write("\n".join(hidden))
     with open(config.HIDDEN_PRODUCTION_FILE, 'w') as file:
+        file.write("\n".join(hidden))
+
+    hidden = hidden_folders.split(",")
+    with open(config.HIDDEN_FOLDER, 'w') as file:
+        file.write("\n".join(hidden))
+    with open(config.HIDDEN_PRODUCTION_FOLDER, 'w') as file:
         file.write("\n".join(hidden))
 
 

--- a/sitemap.py
+++ b/sitemap.py
@@ -13,7 +13,7 @@ import sentry_sdk
 from sentry_sdk import configure_scope
 from bu_cascade.cascade_connector import Cascade
 
-hidden_pages = []
+hidden_pages = ""
 
 if config.SENTRY_URL:
     from sentry_sdk.integrations.flask import FlaskIntegration
@@ -71,6 +71,7 @@ def get_md_dict(md):
 
 
 def inspect_page(page_id):
+    global hidden_pages
     page = None
     for i in range(1, 10):
         try:
@@ -89,7 +90,7 @@ def inspect_page(page_id):
         path = page['asset']['page']['path']
 
         if 'hide-from-sitemap' in list(md.keys()) and md['hide-from-sitemap'] == "Hide":
-            hidden_pages.append("https://www.bethel.edu/" + path + ",")
+            hidden_pages = hidden_pages + ("https://www.bethel.edu/" + path + ",")
             return
 
         if 'require-authentication' in list(md.keys()) and md['require-authentication'] == "Yes":
@@ -179,10 +180,7 @@ sitemap()
 
 
 def hidden_files():
-    hidden = ''
-    for item in hidden_pages:
-        hidden = hidden + str(item)
-    hidden = hidden.split(",")
+    hidden = hidden_pages.split(",")
     with open(config.HIDDEN_FILE, 'w') as file:
         file.write("\n".join(hidden))
     with open(config.HIDDEN_PRODUCTION_FILE, 'w') as file:

--- a/sitemap.py
+++ b/sitemap.py
@@ -178,7 +178,8 @@ def sitemap():
 
 sitemap()
 
-
+# Takes in a string containing the hidden files and splits them based on commas.
+# Writes them to HIDDEN_FILE and HIDDEN_PRODUCTION_FILE
 def hidden_files():
     hidden = hidden_pages.split(",")
     with open(config.HIDDEN_FILE, 'w') as file:


### PR DESCRIPTION
## Description

Adds the pages hidden from sitemap to two new .txt files HIDDEN_PAGES_FILE and HIDDEN_PAGES_PRODUCTION_FILE
Also adds the folders hidden from sitemap to two new .txt files HIDDEN_FOLDERS_FILE and HIDDEN_FOLDERS_PRODUCTION_FILE

Fixes # (ITS-210093)
https://jira.bethel.edu/browse/ITS-210093

## Size and Type of change

- Small Change - 1 person needs to review this

- New feature

- Config update needed

## How Has This Been Tested?

I changed the SITEMAP_BASE_FOLDER_ID to a few different Bethel pages using cms.bethel.edu and the hidden pages and folders lined up with the ones that had "hide from sitemap" checked

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)